### PR TITLE
Add generete-and-export-a-list-of-all-holidays-to-pdf functionality

### DIFF
--- a/all_holidays_in_the_year.html
+++ b/all_holidays_in_the_year.html
@@ -20,6 +20,10 @@
     <link rel="stylesheet" href="./libs/bootstrap-icons/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
 
     <!-- jsPDF -->
+    <script src="./libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+
+    <!-- Moment -->
+    <script src="./libs/moment/2.29.1/moment.min.js"></script>
 
     <!-- Custom CSS -->
     <style>
@@ -35,78 +39,221 @@
     </style>
 </head>
 <body>
-    <div id="container" class="d-flex align-items-center justify-content-center" style="min-height: 100vh;">
+<div id="container" class="d-flex align-items-center justify-content-center" style="min-height: 100vh;">
     <!-- The container div is used to center the body content horizontally and vertically using Bootstrap classes.
     1. The class .d-flex creates a flex container.
     2. The class .align-items-center vertically centers the content within the flex container.
     3. The class .justify-content-center horizontally centers the content within the flex container. -->
 
-        <div class="row">
-            <div class="col-md-12">
+    <div class="row">
+        <div class="col-md-12">
+            <div>
+                <!-- Heading displaying the list of holidays for a specific year -->
+                <h2>List of Holidays for Year <span id="year"></span>:</h2>
+                <!-- Unordered list element that will contain the holiday items -->
+                <ul id="holidays"></ul>
+            </div>
+            <div>
                 <div>
-                    <!-- Heading displaying the list of holidays for a specific year -->
-                    <h2>List of Holidays for Year <span id="year"></span>:</h2>
-                    <!-- Unordered list element that will contain the holiday items -->
-                    <ul id="holidays">Here it will be the list of public and church holidays. The list will be created in js script.</ul>
+                    <!-- Back to the form button -->
+                    <a href="form.html" class="btn btn-secondary">Back to the form</a>
                 </div>
-                <div>
-                    <div>
-                        <!-- Back to the form button -->
-                        <a href="form.html" class="btn btn-secondary">Back to the form</a>
-                    </div>
-                    <div id="button-back-to-the-calendar">
-                        <!-- Back to the calendar button -->
-                        <button type="button" class="btn btn-info" onclick="goBack()">Back to the calendar</button>
-                    </div>
-                    <div id="button-export-to-pdf">
-                        <!-- Export to PDF button -->
-                        <button type="button" class="btn btn-primary" id="export-to-pdf"><i class="bi bi-file-pdf"></i> Export to PDF: List of Holidays for this Year</button>
-                    </div>
+                <div id="button-back-to-the-calendar">
+                    <!-- Back to the calendar button -->
+                    <button type="button" class="btn btn-info" onclick="goBack()">Back to the calendar</button>
+                </div>
+                <div id="button-export-to-pdf">
+                    <!-- Export to PDF button -->
+                    <button type="button" class="btn btn-primary" id="export-to-pdf"><i class="bi bi-file-pdf"></i> Export to PDF: List of Holidays for this Year</button>
                 </div>
             </div>
         </div>
     </div>
-    <script>
-        // get the year parameter from the URL
-        const urlParams = new URLSearchParams(window.location.search);
-        const year = urlParams.get('year');
+</div>
+<script>
+    // get the year parameter from the URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const year = urlParams.get('year');
 
-    // In this js script, there will be functions like this:
-    // *function to get all public holidays for the given year
-        function getPublicHolidays(year) {
+    // function to get all public holidays for the given year
+    function getPublicHolidays(year) {
+        // Define an array of holiday objects for the given year
+        var holidays = [
+            // public holidays
+            {date: new Date(year, 4, 1), name: 'Labour Day', type: 'Public holiday'},
+            {date: new Date(year, 4, 3), name: 'May 3rd Constitution Day', type: 'Public holiday'},
+            {date: new Date(year, 10, 11), name: 'Independence Day', type: 'Public holiday'}
+        ];
 
+        // return a list of public holidays for the given year
+        return holidays;
+    }
+
+    // function to get all church holidays for the given year
+    function getChurchHolidays(year) {
+        // Calculate the date for Easter Monday based on the given year
+        var easterMonday = getEaster(year);
+        easterMonday.setDate(easterMonday.getDate() + 1);
+
+        // Define an array of holiday objects for the given year
+        var holidays = [
+            // church holidays
+            {date: new Date(year, 0, 1), name: 'New Year', type: 'Church holiday'},
+            {date: new Date(year, 0, 6), name: 'Feast of the Three Kings', type: 'Church holiday'},
+            {date: getEaster(year), name: 'Easter', type: 'Church holiday'},
+            {date: easterMonday, name: 'Easter Monday', type: 'Church holiday'},
+            {date: getCorpusChristi(year), name: 'Corpus Christi', type: 'Church holiday'},
+            {date: new Date(year, 7, 15), name: 'Assumption of Mary', type: 'Church holiday'},
+            {date: new Date(year, 10, 1), name: 'All Saints\' Day', type: 'Church holiday'},
+            {date: new Date(year, 11, 25), name: '1st day of Christmas', type: 'Church holiday'},
+            {date: new Date(year, 11, 26), name: '2nd day of Christmas', type: 'Church holiday'}
+        ];
+
+        // function to calculate Easter date for the given year
+        function getEaster(year) {
+            var a = year % 19;
+            var b = Math.floor(year / 100);
+            var c = year % 100;
+            var d = Math.floor(b / 4);
+            var e = b % 4;
+            var f = Math.floor((b + 8) / 25);
+            var g = Math.floor((b - f + 1) / 3);
+            var h = (19 * a + b - d - g + 15) % 30;
+            var i = Math.floor(c / 4);
+            var k = c % 4;
+            var l = (32 + 2 * e + 2 * i - h - k) % 7;
+            var m = Math.floor((a + 11 * h + 22 * l) / 451);
+            var n = Math.floor((h + l - 7 * m + 114) / 31);
+            var p = (h + l - 7 * m + 114) % 31;
+
+            // Return a new Date object representing the Easter date for the given year
+            return new Date(year, n - 1, p + 1);
         }
 
-    // *function to get all church holidays for the given year
-    // (and also functions to calculate dates of movable feasts for the given year: Easter and Corpus Christi).
-        function getChurchHolidays(year) {
+        // function to calculate Corpus Christi date for the given year
+        function getCorpusChristi(year) {
+            var easter = getEaster(year);
+            var corpusChristi = new Date(easter.getTime());
+            corpusChristi.setDate(easter.getDate() + 60);
 
+            // Return a new Date object representing the Corpus Christi date for the given year
+            return corpusChristi;
         }
 
-        // set the year in the page title and heading
-        document.title = `Church Holidays and Public Holidays for Year ${year}`;
-        document.getElementById('year').textContent = year;
+        // return a list of church holidays for the given year
+        return holidays;
+    }
 
-    // Here will be the code for the list of public and church holidays.
-    // After organized list of holidays will be created, this list will be displayed on the page.
+    // set the year in the page title and heading
+    document.title = `Church Holidays and Public Holidays for Year ${year}`;
+    document.getElementById('year').textContent = year;
 
-    // *it will be implemented function to generate the PDF document using jsPDF library.
-    // The function will be connected to the button with Id: export-to-pdf
-        function generatePDF(year) {
+    // get the list of public and church holidays
+    const publicHolidays = getPublicHolidays(year);
+    const churchHolidays = getChurchHolidays(year);
 
-        }
+    // combine the two lists into one list of all holidays
+    const allHolidays = publicHolidays.concat(churchHolidays);
 
-    // Function to navigate back to the previous page (take_your_days_off.html).
-        function goBack() {
-            // Retrieve the query string from the current URL
-            var yearParam = window.location.search;
+    // sort the list of holidays by date
+    allHolidays.sort((a, b) => new Date(a.date) - new Date(b.date));
 
-            // Construct the new URL by appending the query string to "take_your_days_off.html"
-            var newURL = "take_your_days_off.html" + yearParam;
+    // add each holiday to the list in the page
+    const holidaysList = document.getElementById('holidays');
+    allHolidays.forEach(holiday => {
+        const li = document.createElement('li');
+        const date = new Date(holiday.date).toDateString();
+        li.textContent = `${holiday.name + " - " + holiday.type} (${date})`;
 
-            // Navigate to the new URL
-            window.location.href = newURL;
-        }
-    </script>
+        if (holiday.type === 'Church holiday') li.style.color = 'red';  // set the font color to red if the list item is of type: Church holiday
+        if (holiday.type === 'Public holiday') li.style.color = 'orange';  // set the font color to orange if the list item is of type: Public holiday
+        holidaysList.appendChild(li);
+    });
+
+    // Function to generate the PDF document
+    function generatePDF(year) {
+        // Assign the jsPDF library to the global window object
+        window.jsPDF = window.jspdf.jsPDF;
+
+        // Create a new jsPDF instance with 'portrait' orientation, 'pt' units, and 'a4' page size
+        const doc = new jsPDF('p', 'pt', 'a4');
+
+        // Get the list of public and church holidays for the given year
+        const publicHolidays = getPublicHolidays(year);
+        const churchHolidays = getChurchHolidays(year);
+
+        // Combine the two lists into one list of all holidays
+        const allHolidays = publicHolidays.concat(churchHolidays);
+
+        // The starting y-coordinate for adding text in the PDF document
+        let startY = 30;
+
+        // Sort holidays by date
+        allHolidays.sort((a, b) => a.date - b.date);
+
+        // Set the font style to bold
+        doc.setFont("Helvetica", "bold");
+
+        // Set the font size to 15 points
+        doc.setFontSize(15);
+
+        // Add the title to the PDF document
+        doc.text(`List of Holidays for Year ${year}`, 20, startY);
+
+        // Increase the y-coordinate by 30 units to move to the next line for adding text in the PDF document
+        startY += 30;
+
+        // Set the font style to normal
+        doc.setFont("Helvetica", "normal");
+
+        // Iterate over each holiday and add it to the PDF document
+        allHolidays.forEach((holiday, index) => {
+            const {date, name, type} = holiday;
+
+            // Set the text color to red if the holiday is of type Church holiday, or orange if it is of type Public holiday
+            if (holiday.type === 'Church holiday') doc.setTextColor(255,0,0);
+            if (holiday.type === 'Public holiday') doc.setTextColor('orange');
+
+            // Add the holiday information to the PDF document
+            doc.text(`${index+1}.) ${name} - ${type} (${date.toDateString()})`, 20, startY);
+
+            // Increase the y-coordinate by 30 units to move to the next line for adding the next holiday information in the PDF document
+            startY += 30;
+        });
+
+        // Get the current date formatted as 'DD-MM-YYYY'
+        const today_formatted_date = moment().format('DD-MM-YYYY');
+
+        // Create a filename for the PDF document
+        const filename = `all_holidays_in_${year}` + "-saved_" + today_formatted_date + ".pdf";
+
+        // Save the PDF document with the specified filename
+        doc.save(filename);
+    }
+
+    // Event listener for the DOMContentLoaded event, which triggers when the HTML document has finished loading and parsing
+    // This function will be executed once the DOM is fully loaded and ready to be manipulated
+    document.addEventListener('DOMContentLoaded', function() {
+        // Register event listener for the Export to PDF button
+        document.getElementById('export-to-pdf').addEventListener('click', function() {
+            // get the year parameter from the URL
+            const urlParams = new URLSearchParams(window.location.search);
+            const year = urlParams.get('year');
+            generatePDF(year);  // Generate the PDF document for the specified year
+        });
+    });
+
+    // Function to navigate back to the previous page (take_your_days_off.html)
+    function goBack() {
+        // Retrieve the query string from the current URL
+        var yearParam = window.location.search;
+
+        // Construct the new URL by appending the query string to "take_your_days_off.html"
+        var newURL = "take_your_days_off.html" + yearParam;
+
+        // Navigate to the new URL
+        window.location.href = newURL;
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
Implement new features (for all_holidays_in_the_year.html) connected with generete list of all holidays and export them to the pdf:
- Generate a list of church and public holidays in the selected year
- Implement export the list of all holidays days using jsPDF librarary to the pdf list.

Attention!
* The necessary JS libs were included earlier: jspdf, jspdf-autotable, moment - these libs were added earlier in commit: Merge branch new-feature/selection-functionality into main (#2).
* Implementation of new functions is inside <script> section in all_holidays_in_the_year.html. These functions generate a list of church and public holidays in the selected year, and export them to the pdf.